### PR TITLE
Remove link to GitHub issues

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -17,7 +17,6 @@ Searching the list archive is another good way to find answers.
 
 **Bug tracker**  
 Please report bugs at [bugs.ledger-cli.org](http://bugs.ledger-cli.org) (Bugzilla).
-(There is also a [github issue tracker](http://git.ledger-cli.org/ledger/issues) but Bugzilla is preferred.)
 
 **Code**  
 The [ledger source code](http://git.ledger-cli.org/) is available on Github, contributions welcome!


### PR DESCRIPTION
Removes the link to GitHub issues.

To test-build this I updated the files to Hakyll 4.3 (the default that got installed) -- would you be interested in these changes? I don't know how you run this on the server, maybe you need to keep the version.
