### PR TITLE
Add Travis CI build badge to download page

### DIFF
--- a/download.md
+++ b/download.md
@@ -5,6 +5,7 @@ title: Download - Ledger
 # Getting ledger
 
 The [ledger source code](http://git.ledger-cli.org/) is available on Github.
+[![Build Status](https://travis-ci.org/ledger/ledger.png?branch=master)](https://travis-ci.org/ledger/ledger)
 
 Several people in the Open Source community have spent time creating
 Ledger binaries for specific platforms. If you discover others or would


### PR DESCRIPTION
Please note that one of the ledger collaborators needs to activate continuous integration builds for the official ledger repository in Travis CI.

@jwiegley [said](https://groups.google.com/d/msg/ledger-cli/pK8mGsAjb5s/WL1PyzUJKyMJ) he'd set it up this week.
