### PR TITLE
Update version info for Mac OS X Homebrew

### DIFF
--- a/download.md
+++ b/download.md
@@ -15,9 +15,9 @@ like to have a binary hosted, please
   GNU/Linux                                                                                      Windows                                                                              Mac OS X
   ---------------------------------------------------------------------------------------------- ------------------------------------------------------------------------------------ -----------------------------------------------------------------------------------------------------------------------------------------------------
   [Ubuntu](https://launchpad.net/~mbudde/+archive/ledger) (3.0)                                  [AlexanderAA's binary](https://github.com/AlexanderAA/ledger_binaries_windows) (2.6)  [John's ledger.dmg](http://ftp.newartisans.com/pub/ledger/ledger-devel-3.0.0-20120510.dmg) (3.0, needs Snow Leopard or Lion)
-  [Debian](http://packages.qa.debian.org/l/ledger.html) (2.6, 3.0)                                                                                                                    `brew install ledger --HEAD` (3.0)
-  [Gentoo](http://packages.gentoo.org/package/app-office/ledger) (2.6)                                                                                                                `brew install ledger` (2.6)
-  [Arch Linux](https://aur.archlinux.org/packages/ledger/) (3.0.3)                                                                                                                   `fink install ledger` (2.6)
-  [CentOS 6](http://pkgs.org/centos-6-rhel-6/epel-i386/ledger-2.6.3-2.el6.i686.rpm.html) (2.6)                                                                                        `port install ledger` (2.6)
+  [Debian](http://packages.qa.debian.org/l/ledger.html) (2.6, 3.0)                                                                                                                    `brew install ledger` (3.1)
+  [Gentoo](http://packages.gentoo.org/package/app-office/ledger) (2.6)                                                                                                                `fink install ledger` (2.6)
+  [Arch Linux](https://aur.archlinux.org/packages/ledger/) (3.0.3)                                                                                                                    `port install ledger` (2.6)
+  [CentOS 6](http://pkgs.org/centos-6-rhel-6/epel-i386/ledger-2.6.3-2.el6.i686.rpm.html) (2.6)
   [Nixpkgs](http://hydra.nixos.org/job/nixpkgs/trunk/ledger/) (2.6)
 


### PR DESCRIPTION
Via Homebrew only version 3.1 can be installed at the moment.
