### PR TITLE
update link to stable 3.1.1 download

### DIFF
--- a/download.md
+++ b/download.md
@@ -26,5 +26,5 @@ like to have a binary hosted, please
   [Slackware](http://slackbuilds.org/repository/14.1/business/ledger/) (3.1)
   [CentOS 7](http://pkgs.org/centos-7/epel-testing-x86_64/ledger-3.1-2.el7.x86_64.rpm.html) (3.1)
   [OpenSUSE](http://software.opensuse.org/package/ledger?search_term=ledger) (3.1)
-  [Nixpkgs](http://hydra.nixos.org/job/nixpkgs/trunk/ledger/) (2.6)
+  [Nixpkgs](https://hydra.nixos.org/job/nixos/release-17.09/nixpkgs.ledger.x86_64-linux) (3.1.1)
 


### PR DESCRIPTION
It may make sense to link to the  nix package search depending on what channels users have configured: https://nixos.org/nixos/packages.html.