### PR TITLE
Fix the link to the issues page

### DIFF
--- a/source/contribute.html.md
+++ b/source/contribute.html.md
@@ -16,7 +16,7 @@ see [gmane.comp.finance.ledger.general](http://dir.gmane.org/gmane.comp.finance.
 Searching the list archive is another good way to find answers.
 
 **Bug tracker**  
-Please report bugs at [bugs.ledger-cli.org](http://bugs.ledger-cli.org) (Bugzilla).
+Please report bugs at the [github issue page](https://github.com/ledger/ledger/issues).
 
 **Code**  
 The [ledger source code](http://git.ledger-cli.org/) is available on Github, contributions welcome!


### PR DESCRIPTION
Just a small change that modifies the link to the bug tracker from bugs.ledger-cli.org to the actual github issue page.

Of course you could argue that we should actually change the redirection (as it is described in in the about page). So we could redirect from bugs.ledger-cli.org to https://github.com/ledger/ledger/issues. Then we would simply have to remove the text that specifies what bug tracker is behind the link, i.e. the text "(Bugzilla)"