### PR TITLE
Update version.texi to 3.3.1

### DIFF
--- a/version.texi
+++ b/version.texi
@@ -1,8 +1,8 @@
 @set Ledger_VERSION_MAJOR 3
-@set Ledger_VERSION_MINOR 2
+@set Ledger_VERSION_MINOR 3
 @set Ledger_VERSION_PATCH 1
-@set Ledger_VERSION_PRERELEASE
-@set Ledger_VERSION_DATE 20200518
+@set Ledger_VERSION_PRERELEASE 
+@set Ledger_VERSION_DATE 20230303
 
 @set VERSION @value{Ledger_VERSION_MAJOR}.@value{Ledger_VERSION_MINOR}.@value{Ledger_VERSION_PATCH}@value{Ledger_VERSION_PRERELEASE}
 


### PR DESCRIPTION
In order for the correct ledger version number to appear in the documentation `version.texi` must be copied from a ledger workspace after `cmake` has been run.